### PR TITLE
Removed cleanup when saving to .tex

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -771,10 +771,8 @@ function save(filename::AbstractString, o::Plottable; include_preamble::Bool=tru
         cleanup(o)
     elseif ext == ".tex"
         save(TEX(filename, include_preamble=include_preamble), plot(o))
-        cleanup(o)
     elseif ext == ".tikz"
         save(TIKZ(filename), plot(o))
-        cleanup(o)
     elseif ext == "." || ext == ""
         error("You must specify a file extension.")
     else


### PR DESCRIPTION
addresses JuliaTex/TikzPictures.jl#43

Removes `cleanup` operation when saving to .tex or .tikz file. 

This way, temporary png, generated by the `Image` command are still around to be inserted in the .tex file.