### PR TITLE
Check if we can plot before calling Base.show()

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -780,10 +780,23 @@ function axisOptions(p::Image)
     end
 end
 
+canPlot(p::Axis) = all(map(canPlot, p.plots))
+canPlot(axes::Axes) = all(map(canPlot, axes))
+canPlot(p::GroupPlot) = all(map(canPlot, p.axes))
+canPlot(p::Plot) = true
+canPlot(p::Circle) = true
+canPlot(p::Ellipse) = true
+canPlot(p::Command) = true
+canPlot(p::Image) = isfile(p.filename)
+canPlot(p::Contour) = true
+canPlot(p::TikzPicture) = true
+
 function Base.show(f::IO, a::MIME"image/svg+xml", p::Plottable)
-    r = Base.show(f, a, plot(p))
-    cleanup(p)
-    r
+    if canPlot(p)
+        r = Base.show(f, a, plot(p))
+        cleanup(p)
+        r
+    end
 end
 
 function save(filename::AbstractString, o::Plottable; include_preamble::Bool=true)


### PR DESCRIPTION
This addresses #114, where Interact calls Base.show() twice initially, resulting in an error during the second call when using PGFPlots.Image. This pull request adds a function canPlot() written in the style of the cleanup function that checks if the object can be safely plotted. If the object cannot be plotted because p.filename has already been removed during a previous cleanup, then nothing is returned. As a result, if Interact initially calls Base.show() twice, nothing will be shown. However, changing any of the sliders or buttons will call Base.show again (but only once) and plots will appear. If Interact is fixed in the future to only call Base.show once initially, then this code will have no impact. This allows PGFPlots.Image to be used with Interact as is without errors.