### PR TITLE
Ternary Axis

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -1,7 +1,7 @@
 module PGFPlots
 
 export LaTeXString, @L_str, @L_mstr
-export plot, ErrorBars, Axis, Axes, PolarAxis, GroupPlot, Plots, ColorMaps, save, define_color
+export plot, ErrorBars, Axis, Axes, PolarAxis, TernaryAxis, GroupPlot, Plots, ColorMaps, save, define_color
 export pushPGFPlotsOptions, popPGFPlotsOptions, resetPGFPlotsOptions, pgfplotsoptions
 export pushPGFPlotsPreamble, popPGFPlotsPreamble, resetPGFPlotsPreamble, pgfplotspreamble
 export pushPGFPlots, popPGFPlots
@@ -218,6 +218,13 @@ mutable struct Axis
 end
 
 PolarAxis(args...; kwargs...) = Axis(args...; kwargs..., axisKeyword = "polaraxis")
+function TernaryAxis(args...; kwargs...)
+    ternary_axis_string = "\\usepgfplotslibrary{ternary}"
+    if ternary_axis_string ∉ _pgfplotspreamble
+        pushPGFPlotsPreamble(ternary_axis_string)
+    end
+    return Axis(args...; kwargs..., axisKeyword = "ternaryaxis")
+end
 
 const Axes = Vector{Axis}
 


### PR DESCRIPTION
Added support for ternary axes, in a similar manner to the `PolarAxis` type. 
![Selection_028](https://user-images.githubusercontent.com/3334079/60390670-67dcc300-9a90-11e9-919f-6507a136d1f3.png)
