### PR TITLE
Change alignment of MatrixPlot, fix off by one error.

### DIFF
--- a/src/plots.jl
+++ b/src/plots.jl
@@ -480,10 +480,10 @@ mutable struct MatrixPlot <: Plot
 
         (rows,cols) = size(A)
         if xrange == nothing
-            xrange = (1,cols)
+            xrange = (0.5,cols+0.5)
         end
         if yrange == nothing
-            yrange = (1,rows)
+            yrange = (0.5,rows+0.5)
         end
         if zmin == nothing
             zmin = minimum(A[.!isnan.(A)])
@@ -516,10 +516,10 @@ mutable struct MatrixPlot <: Plot
             end
         else
             out = Array{Any}(undef,length(A)+1,3)
-            x = range(xrange[1], stop=xrange[2], length=cols)
-            y = range(yrange[1], stop=yrange[2], length=rows)
-            x = x .- step(x)/2
-            y = y .- step(y)/2
+            xlength = (xrange[2] - xrange[1]) / cols
+            ylength = (yrange[2] - yrange[1]) / rows
+            x = range(xrange[1]+xlength/2, stop=xrange[2]-xlength/2, length=cols)
+            y = range(yrange[1]+ylength/2, stop=yrange[2]-ylength/2, length=rows)
             out[1,:] = ['x', 'y', "data"]
             for i in 1:rows
                 for j in 1:cols


### PR DESCRIPTION
The 'pixels' of MatrixPlots are now centered at their coordinates, e.g.
`MatrixPlot(rand(2, 2), (1, 2), (1, 2))` produces a plot containing four
'pixels' centered at the coordinates (1, 1), (1, 2), (2, 1) and (2, 2).
To accommodate for the size of the 'pixels' which is given by the
step sizes in x- and y-direction the plot ranges are increased by half
their step size for the lower and upper limit, in this example we obtain: xlims=(0.5, 2.5),
ylims=(0.5, 2.5).

The previous calculations for x- and ylimits were incorrect. Considering
above example the previous code takes the given x- and yrange as limits,
which means one obtains a plot showing the x- and y-intervals (1, 2)
having a length of 1. However, the step size is 1 and thus the 'pixels'
have a 'width' and 'height' of 1. But the plot shows only the area for
(1, 2)x(1, 2) which fits one but not all four 'pixels'.
In the general case this leads to the first column and last row of a
given Matrix not to be shown.