### PR TITLE
Enable the limit_to argument from TikzPictures v3.2.0.

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -891,7 +891,7 @@ function Base.show(f::IO, a::MIME"image/svg+xml", p::Plottable)
     end
 end
 
-function save(filename::AbstractString, o::Plottable; include_preamble::Bool=true)
+function save(filename::AbstractString, o::Plottable; include_preamble::Bool=true, limit_to::Symbol=:default)
     _, ext = splitext(filename)
     ext = lowercase(ext)
     if ext == ".pdf"
@@ -901,7 +901,12 @@ function save(filename::AbstractString, o::Plottable; include_preamble::Bool=tru
         save(SVG(filename), plot(o))
         cleanup(o)
     elseif ext == ".tex"
-        save(TEX(filename, include_preamble=include_preamble), plot(o))
+        # limit_to requires TikzPictures v3.2.0; only use if specified
+        if limit_to != :default
+            save(TEX(filename; limit_to=limit_to), plot(o))
+        else
+            save(TEX(filename, include_preamble=include_preamble), plot(o))
+        end
     elseif ext == ".tikz"
         save(TIKZ(filename), plot(o))
     elseif ext == "." || ext == ""


### PR DESCRIPTION
The latest release of TikzPictures.jl offers the possibility to optionally omit the `document` and `tikzpicture` environments. The first of these environments could already be omitted in earlier versions of TikzPictures, by setting `ìnclude_preamble=false`. Omitting the `tikzpicture` is a new feature, which can be useful when embedding the generated TEX files in a larger document: https://github.com/JuliaTeX/TikzPictures.jl/pull/56

This PR is bringing the new feature of TikzPictures to PGFPlots.jl. Backwards compatibility to earlier versions of TikzPictures is maintained.

## Having the new TikzPictures v3.2.0

TEX files can omit the `document` environment by setting either `include_preamble=false` (like in earlier versions) or by equivalently setting `limit_to=:picture`. If the `tikzpicture` environment should also be omitted, you can set `limit_to=:data`.

Let us pin TikzPictures.jl to the new version and test the new feature:

```julia
using Pkg
Pkg.activate(".")
Pkg.pin(PackageSpec(name="TikzPictures", version=v"3.2.0"))

using PGFPlots # requires precompilation due to Pkg.pin
x = [1,2,3]
y = [2,4,1]
save("test.tex", plot(x, y); include_preamble=false) # works
save("test.tex", plot(x, y); limit_to=:picture) # equivalent result
save("test.tex", plot(x, y); limit_to=:data) # the new feature works, too
```

## Having TikzPictures v3.1.0 (or older)

With earlier versions of TikzPictures, `PGFPlots.save` works just like before if no keyword argument is given, or if only `include_preamble` is specified.
This behaviour is achieved by only delegating the new `limit_to` argument if it is actually specified by the user.

Let us pin TikzPictures to an earlier version (don't forget to `] free TikzPictures` afterwards).

```julia
using Pkg
Pkg.activate(".")
Pkg.pin(PackageSpec(name="TikzPictures", version=v"3.1.0"))

using PGFPlots # requires precompilation due to Pkg.pin
x = [1,2,3]
y = [2,4,1]
save("test.tex", plot(x, y); include_preamble=false) # works
save("test.tex", plot(x, y); limit_to=:picture) # has to break (feature not yet supported)
```

If `PGFPlots.save` breaks from a `limit_to` specification, it tells the user that the corresponding `TikzPictures` function does not exist. The message thus hints to the version problem and suggests to use `include_preamble` instead.

```
ERROR: MethodError: no method matching TikzPictures.TEX(::String; limit_to=:picture)
Closest candidates are:
  TikzPictures.TEX(::AbstractString; include_preamble) at ... got unsupported keyword argument "limit_to"
```

Due to this behaviour, we do not need to make TikzPictures >= v3.2.0 a hard requirement in the `Project.toml`. If a later version of TikzPictures is installed in the user environment (e.g. by `] up`), the new feature will work. If it is not, it won't, but `include_preamble` is a working fallback solution.
