### PR TITLE
Wrap legend entries to allow for commas (#156)

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -703,8 +703,7 @@ function plotHelper(o::IO, axis::Axis)
     legendentries = vcat(legendentries...) # flatten
     # avoid adding \legend altogether if all entries are `nothing`
     if !all(legendentries .=== nothing)
-        legendentries = replace(legendentries, nothing=>"") # for correct printing
-        legendcontent = join(legendentries, ',')
+        legendcontent = join(map(x->x === nothing ? "" : "{}{$x}", legendentries), ", ")
         println(o, "\\legend{$legendcontent}") # add legend
     end
 end


### PR DESCRIPTION
This addresses #156 based on advice from https://tex.stackexchange.com/questions/129624/comma-in-legend-in-pgfplots (i.e. wrap entries with `{}{beta(1,2)}`)

Tested on several stressing legend examples and works like a charm.