### PR TITLE
Back to \addlegendentry

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -13,14 +13,9 @@ using Discretizers
 using Printf
 
 # Define isnothing
-macro define_isnothing_if_needed()
-    if VERSION < v"1.1"
-        return :( isnothing(x) = x === nothing )
-    else
-        return :()
-    end
+if VERSION < v"1.1"
+    isnothing(x) = x === nothing
 end
-@define_isnothing_if_needed
 
 # load dynamic dependencies
 function __init__()
@@ -449,11 +444,6 @@ end
 #       commas are properly parsed. Otherwise, an entry like $beta(1,2)$ will fail to compile.
 plotLegend(o::IO, entry) = nothing
 plotLegend(o::IO, entry::AbstractString) = println(o, "\\addlegendentry{{}{$entry}}")
-function plotLegend(o::IO, entries::Vector{T}) where {T <: AbstractString}
-    for entry in entries
-        plotLegend(o, entry)
-    end
-end
 
 # todo: add error bars style
 function plotHelperErrorBars(o::IO, p::Linear)

--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -13,9 +13,14 @@ using Discretizers
 using Printf
 
 # Define isnothing
-if VERSION < v"1.1"
-    isnothing(x) = x === nothing
+macro define_isnothing_if_needed()
+    if VERSION < v"1.1"
+        return :( isnothing(x) = x === nothing )
+    else
+        return :()
+    end
 end
+@define_isnothing_if_needed
 
 # load dynamic dependencies
 function __init__()

--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -12,6 +12,11 @@ using Requires
 using Discretizers
 using Printf
 
+# Define isnothing
+if VERSION < v"1.1"
+    isnothing(x) = x === nothing
+end
+
 # load dynamic dependencies
 function __init__()
     @require DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0" include("dataframes.jl")

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -299,15 +299,15 @@ mutable struct Image <: Plot
         ) where {T <: Real}
 
         global _imgid
-        if filename == nothing
+        if isnothing(filename)
             id=myid()*10000000000000+_imgid
             filename = "tmp_$(id).png"
             _imgid += 1
         end
-        if zmin == nothing
+        if isnothing(zmin)
             zmin = minimum(A)
         end
-        if zmax == nothing
+        if isnothing(zmax)
             zmax = maximum(A)
         end
         if zmin == zmax
@@ -382,13 +382,13 @@ function Histogram2(
         M = M * scale
     end
     if zmode == "log"
-        if zmin == nothing
+        if isnothing(zmin)
             if minimum(M) == 0
                 nonzeromin = minimum(M[findall(x->x!=0, M)])
                 M = replace!(Float64.(M), 0. =>nonzeromin/2)
                 M = log10.(M)
             end
-        elseif zmin <= 0
+        elseif zmin ≤ 0
             error("zmin must be > 0 for a valid log10 output")
         else
             M = replace!(Float64.(M), 0. =>zmin)
@@ -490,33 +490,33 @@ mutable struct MatrixPlot <: Plot
         ) where {T <: Real}
 
         global _imgid
-        if filename == nothing
+        if isnothing(filename)
             id=myid()*10000000000000+_imgid
             filename = "tmp_$(id).dat"
             _imgid += 1
         end
 
         (rows,cols) = size(A)
-        if xrange == nothing
+        if isnothing(xrange)
             xrange = (0.5,cols+0.5)
         end
-        if yrange == nothing
+        if isnothing(yrange)
             yrange = (0.5,rows+0.5)
         end
-        if zmin == nothing
+        if isnothing(zmin)
             zmin = minimum(A[.!isnan.(A)])
         end
-        if zmax == nothing
+        if isnothing(zmax)
             zmax = maximum(A[.!isnan.(A)])
         end
-        if zmin == zmax
+        if isnothing(zmin)
             zmin -= 1.0
             zmax += 1.0
         end
 
-        if length(A) <= 1e4
+        if length(A) ≤ 1e4
             raster = false
-        elseif raster == nothing
+        elseif isnothing(raster)
             @warn "Matrix is too large for vector plotting, consider switching to raster mode."
             raster = true
         end

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -12,6 +12,11 @@ const RealRange = Tuple{Real,Real}
 
 include("ndgrid.jl")
 
+# Define isnothing
+if VERSION < v"1.1"
+    isnothing(x) = x === nothing
+end
+
 abstract type Plot end
 
 mutable struct Linear <: Plot


### PR DESCRIPTION
We recently moved from using `\addlegendentry` for legend entries to having a single `\legend` filing at the end of all of the plot entries. Unfortunately, this approach does not play well with entries that are not included in the legend, such as when "forget plot" is used.

This PR reverts back to using individual `\addlegendentry` calls, but adds in the `{}{entry}` trick that the previous PR used to guard against commas in an entry.

This PR also moves away from === and !== used for `nothing` comparisons in favor of `isnothing` and `!isnothing`.